### PR TITLE
Discardable tasks

### DIFF
--- a/Tests/QueueTests/AsyncQueueTests.swift
+++ b/Tests/QueueTests/AsyncQueueTests.swift
@@ -31,6 +31,30 @@ struct AsyncQueueTests {
     }
     
     @Test
+    func performUnlessCancelled_returns_nonthrowing_operation_value() async throws {
+        let queue = AsyncQueue()
+        
+        for value in 0..<10 {
+            let result = try await queue.performUnlessCancelled {
+                return value
+            }
+            #expect(result == value)
+        }
+    }
+    
+    @Test
+    func performUnlessCancelled_rethrows_thrown_error() async throws {
+        struct TestError: Error { }
+        let queue = AsyncQueue()
+        
+        await #expect(throws: TestError.self) {
+            try await queue.performUnlessCancelled {
+                throw TestError()
+            }
+        }
+    }
+    
+    @Test
     func added_task_returns_nonthrowing_operation_value() async throws {
         let queue = AsyncQueue()
         
@@ -49,6 +73,33 @@ struct AsyncQueueTests {
         let queue = AsyncQueue()
         
         let task = queue.addTask {
+            throw TestError()
+        }
+        
+        await #expect(throws: TestError.self) {
+            try await task.value
+        }
+    }
+    
+    @Test
+    func discardable_task_returns_operation_value() async throws {
+        let queue = AsyncQueue()
+        
+        for value in 0..<10 {
+            let task = queue.addDiscardableTask {
+                return value
+            }
+            let result = try await task.value
+            #expect(result == value)
+        }
+    }
+    
+    @Test
+    func discardable_task_rethrows_thrown_error() async throws {
+        struct TestError: Error { }
+        let queue = AsyncQueue()
+        
+        let task = queue.addDiscardableTask {
             throw TestError()
         }
         
@@ -127,10 +178,43 @@ struct AsyncQueueTests {
         #expect(values == Array(0...10000))
     }
     
+    @Test
+    func discardable_tasks_are_ordered() async throws {
+        let valuesMutex = Mutex<[Int]>([])
+        let queue = AsyncQueue()
+        for i in 0...10000 {
+            queue.addDiscardableTask {
+                valuesMutex.withLock { $0.append(i) }
+            }
+        }
+        let values = await queue.perform {
+            valuesMutex.withLock { $0 }
+        }
+        #expect(values == Array(0...10000))
+    }
+    
+    @Test
+    func cancelled_discardable_tasks_are_ordered() async throws {
+        let valuesMutex = Mutex<[Int]>([])
+        let queue = AsyncQueue()
+        for i in 0...10000 {
+            let task = queue.addDiscardableTask {
+                valuesMutex.withLock { $0.append(i) }
+            }
+            if Bool.random() {
+                task.cancel()
+            }
+        }
+        let values = await queue.perform {
+            valuesMutex.withLock { $0 }
+        }
+        #expect(values == values.sorted())
+    }
+    
     // MARK: - Cancellation
     
     @Test
-    func nonthrowing_operation_is_cancelled_by_late_wrapper_task_cancellation() async throws {
+    func perform_nonthrowing_operation_is_cancelled_by_late_wrapper_task_cancellation() async throws {
         let queue = AsyncQueue()
         
         // Semaphore-like stream: signal is `continuation.finish()`,
@@ -154,7 +238,7 @@ struct AsyncQueueTests {
     }
     
     @Test
-    func throwing_operation_is_cancelled_by_late_wrapper_task_cancellation() async throws {
+    func perform_throwing_operation_is_cancelled_by_late_wrapper_task_cancellation() async throws {
         let queue = AsyncQueue()
         
         // Semaphore-like stream: signal is `continuation.finish()`,
@@ -180,7 +264,7 @@ struct AsyncQueueTests {
     }
     
     @Test
-    func nonthrowing_operation_is_cancelled_by_early_wrapper_task_cancellation() async throws {
+    func perform_nonthrowing_operation_is_cancelled_by_early_wrapper_task_cancellation() async throws {
         let queue = AsyncQueue()
         
         let wrapperTask = Task {
@@ -198,7 +282,7 @@ struct AsyncQueueTests {
     }
     
     @Test
-    func throwing_operation_is_cancelled_by_early_wrapper_task_cancellation() async throws {
+    func perform_throwing_operation_is_cancelled_by_early_wrapper_task_cancellation() async throws {
         let queue = AsyncQueue()
         
         let wrapperTask = Task {
@@ -210,6 +294,106 @@ struct AsyncQueueTests {
                 try await queue.perform {
                     try Task.checkCancellation()
                 }
+            }
+        }
+        
+        wrapperTask.cancel()
+        await wrapperTask.value
+    }
+    
+    @Test
+    func performUnlessCancelled_operation_is_cancelled_by_late_wrapper_task_cancellation() async throws {
+        let queue = AsyncQueue()
+        
+        // Semaphore-like stream: signal is `continuation.finish()`,
+        // wait is `for await _ in stream { }`
+        let (didStartStream, didStartContinuation) = AsyncStream.makeStream(of: Never.self)
+        
+        let wrapperTask = Task {
+            try await queue.performUnlessCancelled {
+                didStartContinuation.finish()
+                
+                // Wait until task is cancelled.
+                let didCancelStream = AsyncStream<Never> { _ in }
+                for await _ in didCancelStream { }
+                #expect(Task.isCancelled)
+            }
+        }
+        
+        for await _ in didStartStream { }
+        wrapperTask.cancel()
+        try await wrapperTask.value
+    }
+    
+    @Test
+    func performUnlessCancelled_operation_is_cancelled_by_early_wrapper_task_cancellation() async throws {
+        let queue = AsyncQueue()
+        
+        let wrapperTask = Task {
+            // Wait until task is cancelled.
+            let didCancelStream = AsyncStream<Never> { _ in }
+            for await _ in didCancelStream { }
+            
+            await #expect(throws: CancellationError.self) {
+                try await queue.performUnlessCancelled {
+                    Issue.record("Operation should not run")
+                }
+            }
+        }
+        
+        wrapperTask.cancel()
+        await wrapperTask.value
+    }
+    
+    @Test
+    func cancelled_discardable_task_does_not_wait_for_previous_operations() async throws {
+        let queue = AsyncQueue()
+        
+        // GIVEN a first task that does not end until the test is complete.
+        let (firstTaskStream, firstTaskContinuation) = AsyncStream.makeStream(of: Never.self)
+        defer { firstTaskContinuation.finish() }
+        queue.addTask {
+            for await _ in firstTaskStream { }
+        }
+        
+        // GIVEN a discardable task enqueued after the first task.
+        let discardableTask = queue.addDiscardableTask {
+            Issue.record("Operation should not run")
+        }
+        
+        // WHEN the discardable task is cancelled,
+        discardableTask.cancel()
+        
+        // THEN it completes with `CancellationError` before the first task has ended.
+        await #expect(throws: CancellationError.self) {
+            try await discardableTask.value
+        }
+    }
+    
+    @Test
+    func cancelled_performUnlessCancelled_does_not_wait_for_previous_operations() async throws {
+        let queue = AsyncQueue()
+        
+        let (firstTaskStream, firstTaskContinuation) = AsyncStream.makeStream(of: Never.self)
+        queue.addTask {
+            for await _ in firstTaskStream { }
+        }
+        
+        let wrapperTask = Task {
+            // Wait until task is cancelled.
+            let didCancelStream = AsyncStream<Never> { _ in }
+            for await _ in didCancelStream { }
+            
+            await #expect(throws: CancellationError.self) {
+                try await queue.performUnlessCancelled {
+                    Issue.record("Operation should not run")
+                }
+            }
+            
+            firstTaskContinuation.finish()
+            
+            await queue.perform {
+                #expect(Task.isCancelled)
             }
         }
         
@@ -252,6 +436,38 @@ struct AsyncQueueTests {
     }
     
     @Test
+    func performUnlessCancelled_closure_inherits_isolation() {
+        // This test passes if it compiles without any error or warning.
+        @MainActor class MyClass {
+            let queue = AsyncQueue()
+            
+            private func enqueue() async throws {
+                try await queue.performUnlessCancelled {
+                    // Synchronous call is OK because the closure inherits
+                    // the current isolation.
+                    isolatedSynchronousMethod()
+                }
+            }
+            
+            private func isolatedSynchronousMethod() { }
+        }
+        
+        actor MyActor {
+            let queue = AsyncQueue()
+            
+            private func enqueue() async throws {
+                try await queue.performUnlessCancelled {
+                    // Synchronous call is OK because the closure inherits
+                    // the current isolation.
+                    isolatedSynchronousMethod()
+                }
+            }
+            
+            private func isolatedSynchronousMethod() { }
+        }
+    }
+    
+    @Test
     func addTask_closure_inherits_isolation() {
         // This test passes if it compiles without any error or warning.
         @MainActor class MyClass {
@@ -273,6 +489,38 @@ struct AsyncQueueTests {
             
             private func enqueue() -> Task<Void, Never> {
                 queue.addTask {
+                    // Synchronous call is OK because the closure inherits
+                    // the current isolation.
+                    isolatedSynchronousMethod()
+                }
+            }
+            
+            private func isolatedSynchronousMethod() { }
+        }
+    }
+    
+    @Test
+    func addDiscardableTask_closure_inherits_isolation() {
+        // This test passes if it compiles without any error or warning.
+        @MainActor class MyClass {
+            let queue = AsyncQueue()
+            
+            private func enqueue() -> Task<Void, any Error> {
+                queue.addDiscardableTask {
+                    // Synchronous call is OK because the closure inherits
+                    // the current isolation.
+                    isolatedSynchronousMethod()
+                }
+            }
+            
+            private func isolatedSynchronousMethod() { }
+        }
+        
+        actor MyActor {
+            let queue = AsyncQueue()
+            
+            private func enqueue() -> Task<Void, any Error> {
+                queue.addDiscardableTask {
                     // Synchronous call is OK because the closure inherits
                     // the current isolation.
                     isolatedSynchronousMethod()


### PR DESCRIPTION
**This pull request was eventually reverted. Original message below.**

---

Before this pull request, `AsyncQueue` would always perform the enqueued operations. Dealing with eventual cancellation is the responsibility of those operations:

```swift
let queue = AsyncQueue()

let addedTask = queue.addTask {
  // Deal with eventual cancellation of addedTask
}

await queue.perform {
  // Deal with eventual cancellation of the current task.
}
```

**This behavior is necessary** for apps that want to ignore cancellation. The task created by `addTask`, as well as the `perform` method, are nonthrowing as long as the enqueued operation does not throw.

**This behavior can create a problem**: cancellation can only be handled after the completion of all previously enqueued operations. The task returned by `addTask` can not throw `CancellationError` as soon as it is cancelled. The `perform` method can not throw `CancellationError` as soon as the current task is cancelled.

This is why this pull requests introduces two new methods, which deal with early cancellation:

```swift
let addedTask = queue.addDiscardableTask {
  // Does not run if addedTask is cancelled before
  // previously enqueued operations complete.
}

try await queue.performUnlessCancelled {
  // Does not run if the current task is cancelled before
  // previously enqueued operations complete.
}
```

Unlike `addTask` and `perform` which can be nonthrowing, `addDiscardableTask` and `performUnlessCancelled` may throw `CancellationError`.

If the task returned by `addDiscardableTask` is cancelled before previously enqueued operations complete, then the operation does not run and the task immediately throws `CancellationError`.

If the task that awaits for `performUnlessCancelled` is cancelled before previously enqueued operations complete, then `performUnlessCancelled` does not run the operation and immediately throws `CancellationError`.

In other cases, the operation runs, and it can handle cancellation as desired.