### PR TITLE
Serialization assertions

### DIFF
--- a/Sources/Queue/AsyncQueue.swift
+++ b/Sources/Queue/AsyncQueue.swift
@@ -56,8 +56,8 @@ public struct AsyncQueue: Sendable {
     /// - Returns: The result of `operation`.
     /// - Throws: The error of `operation`.
     public func perform<Success>(
-        @_inheritActorContext @_implicitSelfCapture operation: () async throws -> sending Success
-    ) async rethrows -> sending Success {
+        @_inheritActorContext @_implicitSelfCapture operation: () async throws -> Success
+    ) async rethrows -> Success {
         let (start, end) = primitiveQueue.makeSemaphores()
         defer { end.signal() }
         await start.wait()

--- a/Sources/Queue/AsyncQueue.swift
+++ b/Sources/Queue/AsyncQueue.swift
@@ -131,3 +131,18 @@ public struct AsyncQueue: Sendable {
         }
     }
 }
+
+extension AsyncQueue: Identifiable {
+    /// The identity of an ``AsyncQueue``.
+    public struct ID: Hashable, Sendable {
+        private let id: PrimitiveAsyncQueue.ID
+        
+        init(id: PrimitiveAsyncQueue.ID) {
+            self.id = id
+        }
+    }
+    
+    public var id: ID {
+        ID(id: primitiveQueue.id)
+    }
+}

--- a/Sources/Queue/AsyncQueue.swift
+++ b/Sources/Queue/AsyncQueue.swift
@@ -33,12 +33,15 @@
 ///
 /// - ``init()``
 ///
-/// ### Performing Operations
+/// ### Instance Methods
 ///
-/// - ``perform(operation:)``
 /// - ``addTask(operation:)->Task<Success,Never>``
 /// - ``addTask(operation:)->Task<Success,Error>``
+/// - ``perform(operation:)``
+/// - ``preconditionSerialized(_:file:line:)``
 public struct AsyncQueue: Sendable {
+    @TaskLocal private static var currentQueueIds = Set<ID>()
+    
     private let primitiveQueue = PrimitiveAsyncQueue()
     
     public init() { }
@@ -59,9 +62,11 @@ public struct AsyncQueue: Sendable {
         @_inheritActorContext @_implicitSelfCapture operation: () async throws -> Success
     ) async rethrows -> Success {
         let (start, end) = primitiveQueue.makeSemaphores()
-        defer { end.signal() }
-        await start.wait()
-        return try await operation()
+        return try await withTaskId {
+            defer { end.signal() }
+            await start.wait()
+            return try await operation()
+        }
     }
     
     /// Returns an unstructured Task that runs the given
@@ -91,10 +96,12 @@ public struct AsyncQueue: Sendable {
         
         let (start, end) = primitiveQueue.makeSemaphores()
         return Task {
-            defer { end.signal() }
-            await start.wait()
-            
-            return await operation()
+            await withTaskId {
+                defer { end.signal() }
+                await start.wait()
+                
+                return await operation()
+            }
         }
     }
     
@@ -124,11 +131,48 @@ public struct AsyncQueue: Sendable {
         
         let (start, end) = primitiveQueue.makeSemaphores()
         return Task {
-            defer { end.signal() }
-            await start.wait()
-            
-            return try await operation()
+            try await withTaskId {
+                defer { end.signal() }
+                await start.wait()
+                
+                return try await operation()
+            }
         }
+    }
+}
+
+extension AsyncQueue {
+    /// Stops program execution if the current task is not executing an
+    /// operation of this queue.
+    ///
+    /// - Parameters:
+    ///   - message: The message to print if the assertion fails.
+    ///   - file: The file name to print if the assertion fails. The default
+    ///     is where this method was called.
+    ///   - line: The line number to print if the assertion fails The
+    ///     default is where this method was called.
+    public func preconditionSerialized(
+        _ message: @autoclosure () -> String = String(),
+        file: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        precondition(Self.currentQueueIds.contains(id), message(), file: file, line: line)
+    }
+    
+    @discardableResult private func withTaskId<R>(
+        operation: () async throws -> R,
+        isolation: isolated (any Actor)? = #isolation,
+        file: String = #fileID,
+        line: UInt = #line
+    ) async rethrows -> R {
+        var ids = Self.currentQueueIds
+        ids.insert(id)
+        return try await Self.$currentQueueIds.withValue(
+            ids,
+            operation: operation,
+            isolation: isolation,
+            file: file,
+            line: line)
     }
 }
 

--- a/Sources/Queue/CoalescingAsyncQueue.swift
+++ b/Sources/Queue/CoalescingAsyncQueue.swift
@@ -87,8 +87,8 @@ public struct CoalescingAsyncQueue: Sendable {
     ///   current task is cancelled before the previously enqueued
     ///   operations complete.
     public func perform<Success>(
-        @_inheritActorContext @_implicitSelfCapture operation: () async throws -> sending Success
-    ) async throws -> sending Success {
+        @_inheritActorContext @_implicitSelfCapture operation: () async throws -> Success
+    ) async throws -> Success {
         // First cancel eventual discardable task
         let cancel = cancellableMutex.withLock { cancel in
             defer { cancel = nil }

--- a/Sources/Queue/CoalescingAsyncQueue.swift
+++ b/Sources/Queue/CoalescingAsyncQueue.swift
@@ -213,3 +213,18 @@ public struct CoalescingAsyncQueue: Sendable {
         return task
     }
 }
+
+extension CoalescingAsyncQueue: Identifiable {
+    /// The identity of a ``CoalescingAsyncQueue``.
+    public struct ID: Hashable, Sendable {
+        private let id: PrimitiveAsyncQueue.ID
+        
+        init(id: PrimitiveAsyncQueue.ID) {
+            self.id = id
+        }
+    }
+    
+    public var id: ID {
+        ID(id: primitiveQueue.id)
+    }
+}

--- a/Sources/Queue/DiscardingAsyncQueue.swift
+++ b/Sources/Queue/DiscardingAsyncQueue.swift
@@ -106,3 +106,18 @@ public struct DiscardingAsyncQueue: Sendable {
         }
     }
 }
+
+extension DiscardingAsyncQueue: Identifiable {
+    /// The identity of a ``DiscardingAsyncQueue``.
+    public struct ID: Hashable, Sendable {
+        private let id: PrimitiveAsyncQueue.ID
+        
+        init(id: PrimitiveAsyncQueue.ID) {
+            self.id = id
+        }
+    }
+    
+    public var id: ID {
+        ID(id: primitiveQueue.id)
+    }
+}

--- a/Sources/Queue/DiscardingAsyncQueue.swift
+++ b/Sources/Queue/DiscardingAsyncQueue.swift
@@ -60,8 +60,8 @@ public struct DiscardingAsyncQueue: Sendable {
     ///   current task is cancelled before the previously enqueued
     ///   operations complete.
     public func perform<Success>(
-        @_inheritActorContext @_implicitSelfCapture operation: () async throws -> sending Success
-    ) async throws -> sending Success {
+        @_inheritActorContext @_implicitSelfCapture operation: () async throws -> Success
+    ) async throws -> Success {
         let (start, end) = primitiveQueue.makeSemaphores()
         defer { end.signal() }
         

--- a/Sources/Queue/DiscardingAsyncQueue.swift
+++ b/Sources/Queue/DiscardingAsyncQueue.swift
@@ -33,11 +33,14 @@
 ///
 /// - ``init()``
 ///
-/// ### Performing Operations
+/// ### Instance Methods
 ///
-/// - ``perform(operation:)``
 /// - ``addTask(operation:)``
+/// - ``perform(operation:)``
+/// - ``preconditionSerialized(_:file:line:)``
 public struct DiscardingAsyncQueue: Sendable {
+    @TaskLocal private static var currentQueueIds = Set<ID>()
+    
     private let primitiveQueue = PrimitiveAsyncQueue()
     
     public init() { }
@@ -63,12 +66,14 @@ public struct DiscardingAsyncQueue: Sendable {
         @_inheritActorContext @_implicitSelfCapture operation: () async throws -> Success
     ) async throws -> Success {
         let (start, end) = primitiveQueue.makeSemaphores()
-        defer { end.signal() }
-        
-        // Stop waiting if task is cancelled.
-        try await start.waitUnlessCancelled()
-        
-        return try await operation()
+        return try await withTaskId {
+            defer { end.signal() }
+            
+            // Stop waiting if task is cancelled.
+            try await start.waitUnlessCancelled()
+            
+            return try await operation()
+        }
     }
     
     /// Returns an unstructured Task that runs the given operation.
@@ -97,13 +102,50 @@ public struct DiscardingAsyncQueue: Sendable {
         
         let (start, end) = primitiveQueue.makeSemaphores()
         return Task {
-            defer { end.signal() }
-            
-            // Stop waiting if task is cancelled.
-            try await start.waitUnlessCancelled()
-            
-            return try await operation()
+            try await withTaskId {
+                defer { end.signal() }
+                
+                // Stop waiting if task is cancelled.
+                try await start.waitUnlessCancelled()
+                
+                return try await operation()
+            }
         }
+    }
+}
+
+extension DiscardingAsyncQueue {
+    /// Stops program execution if the current task is not executing an
+    /// operation of this queue.
+    ///
+    /// - Parameters:
+    ///   - message: The message to print if the assertion fails.
+    ///   - file: The file name to print if the assertion fails. The default
+    ///     is where this method was called.
+    ///   - line: The line number to print if the assertion fails The
+    ///     default is where this method was called.
+    public func preconditionSerialized(
+        _ message: @autoclosure () -> String = String(),
+        file: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        precondition(Self.currentQueueIds.contains(id), message(), file: file, line: line)
+    }
+    
+    @discardableResult private func withTaskId<R>(
+        operation: () async throws -> R,
+        isolation: isolated (any Actor)? = #isolation,
+        file: String = #fileID,
+        line: UInt = #line
+    ) async rethrows -> R {
+        var ids = Self.currentQueueIds
+        ids.insert(id)
+        return try await Self.$currentQueueIds.withValue(
+            ids,
+            operation: operation,
+            isolation: isolation,
+            file: file,
+            line: line)
     }
 }
 

--- a/Sources/Queue/Internal/PrimitiveAsyncQueue.swift
+++ b/Sources/Queue/Internal/PrimitiveAsyncQueue.swift
@@ -1,5 +1,5 @@
 /// A queue that serializes tasks.
-final class PrimitiveAsyncQueue: Sendable {
+final class PrimitiveAsyncQueue: Identifiable, Sendable {
     typealias Operation = @Sendable () async -> Void
     
     private let queueContinuation: AsyncStream<Operation>.Continuation

--- a/Tests/QueueTests/AsyncQueueTests.swift
+++ b/Tests/QueueTests/AsyncQueueTests.swift
@@ -51,6 +51,47 @@ struct AsyncQueueTests {
     }
     
     @Test
+    func perform_returns_non_sendable_value() async throws {
+        class NonSendable { }
+        
+        @globalActor actor MyGlobalActor {
+            static let shared = MyGlobalActor()
+        }
+        
+        let queue = AsyncQueue()
+        
+        do {
+            let value = NonSendable()
+            let result = await queue.perform {
+                return value
+            }
+            #expect(result === value)
+        }
+        
+        // Won't compile.
+        //
+        // do {
+        //     let value = NonSendable()
+        //     let result = await queue.perform { @MyGlobalActor in
+        //         return value
+        //     }
+        //     #expect(result === value)
+        // }
+        
+        do {
+            let _ = await queue.perform {
+                return NonSendable()
+            }
+        }
+        
+        do {
+            let _ = await queue.perform { @MyGlobalActor in
+                return NonSendable()
+            }
+        }
+    }
+
+    @Test
     func perform_rethrows_thrown_error() async throws {
         struct TestError: Error { }
         let queue = AsyncQueue()

--- a/Tests/QueueTests/AsyncQueueTests.swift
+++ b/Tests/QueueTests/AsyncQueueTests.swift
@@ -90,7 +90,7 @@ struct AsyncQueueTests {
             }
         }
     }
-
+    
     @Test
     func perform_rethrows_thrown_error() async throws {
         struct TestError: Error { }
@@ -327,6 +327,116 @@ struct AsyncQueueTests {
         
         wrapperTask.cancel()
         await wrapperTask.value
+    }
+    
+    // MARK: - Serialization precondition
+    
+    @Test
+    func preconditionSerialized() async throws {
+        let queue = AsyncQueue()
+        
+        // Test all ways to run an operation:
+        // - perform
+        // - addTask (non-throwing)
+        // - addTask (throwing)
+        
+        await queue.perform {
+            queue.preconditionSerialized()
+        }
+        
+        await queue
+            .addTask {
+                queue.preconditionSerialized()
+            }
+            .value
+        
+        try await queue
+            .addTask {
+                try Task.checkCancellation()
+                queue.preconditionSerialized()
+            }
+            .value
+    }
+    
+    @Test
+    func preconditionSerialized_for_nested_queues() async throws {
+        let queue1 = AsyncQueue()
+        let queue2 = AsyncQueue()
+        
+        // Test all combinations:
+        // - perform
+        // - addTask (non-throwing)
+        // - addTask (throwing)
+        
+        await queue2.perform {
+            await queue1.perform {
+                queue2.preconditionSerialized()
+                queue1.preconditionSerialized()
+            }
+            
+            await queue1
+                .addTask {
+                    queue2.preconditionSerialized()
+                    queue1.preconditionSerialized()
+                }
+                .value
+            
+            try? await queue1
+                .addTask {
+                    try Task.checkCancellation()
+                    queue2.preconditionSerialized()
+                    queue1.preconditionSerialized()
+                }
+                .value
+        }
+        
+        await queue2
+            .addTask {
+                await queue1.perform {
+                    queue2.preconditionSerialized()
+                    queue1.preconditionSerialized()
+                }
+                
+                await queue1
+                    .addTask {
+                        queue2.preconditionSerialized()
+                        queue1.preconditionSerialized()
+                    }
+                    .value
+                
+                try? await queue1
+                    .addTask {
+                        try Task.checkCancellation()
+                        queue2.preconditionSerialized()
+                        queue1.preconditionSerialized()
+                    }
+                    .value
+            }
+            .value
+        
+        try await queue2
+            .addTask {
+                await queue1.perform {
+                    queue2.preconditionSerialized()
+                    queue1.preconditionSerialized()
+                }
+                
+                await queue1
+                    .addTask {
+                        queue2.preconditionSerialized()
+                        queue1.preconditionSerialized()
+                    }
+                    .value
+                
+                try await queue1
+                    .addTask {
+                        try Task.checkCancellation()
+                        queue2.preconditionSerialized()
+                        queue1.preconditionSerialized()
+                    }
+                    .value
+            }
+            .value
     }
     
     // MARK: - Isolation

--- a/Tests/QueueTests/CoalescingAsyncQueueTests.swift
+++ b/Tests/QueueTests/CoalescingAsyncQueueTests.swift
@@ -631,6 +631,130 @@ struct CoalescingAsyncQueueTests {
         }
     }
     
+    // MARK: - Serialization precondition
+    
+    @Test
+    func preconditionSerialized() async throws {
+        let queue = CoalescingAsyncQueue()
+        
+        // Test all ways to run an operation:
+        // - perform
+        // - addTask
+        
+        try await queue.perform {
+            queue.preconditionSerialized()
+        }
+        
+        try await queue
+            .addTask {
+                queue.preconditionSerialized()
+            }
+            .value
+    }
+    
+    @Test(arguments: [CoalescingAsyncQueue.Policy.required, .discardable])
+    func preconditionSerialized(
+        policy: CoalescingAsyncQueue.Policy
+    ) async throws {
+        let queue = CoalescingAsyncQueue()
+        
+        // Test all ways to run an operation:
+        // - perform(policy:)
+        // - addTask(policy:)
+        
+        try await queue.perform(policy: policy) {
+            queue.preconditionSerialized()
+        }
+        
+        try await queue
+            .addTask(policy: policy) {
+                queue.preconditionSerialized()
+            }
+            .value
+    }
+    
+    @Test
+    func preconditionSerialized_for_nested_queues() async throws {
+        let queue1 = CoalescingAsyncQueue()
+        let queue2 = CoalescingAsyncQueue()
+        
+        // Test all combinations:
+        // - perform
+        // - addTask
+        
+        try await queue2.perform {
+            try await queue1.perform {
+                queue2.preconditionSerialized()
+                queue1.preconditionSerialized()
+            }
+            
+            try await queue1
+                .addTask {
+                    queue2.preconditionSerialized()
+                    queue1.preconditionSerialized()
+                }
+                .value
+        }
+        
+        try await queue2
+            .addTask {
+                try await queue1.perform {
+                    queue2.preconditionSerialized()
+                    queue1.preconditionSerialized()
+                }
+                
+                try await queue1
+                    .addTask {
+                        queue2.preconditionSerialized()
+                        queue1.preconditionSerialized()
+                    }
+                    .value
+            }
+            .value
+    }
+    
+    @Test(arguments: [CoalescingAsyncQueue.Policy.required, .discardable])
+    func preconditionSerialized_for_nested_queues(
+        policy: CoalescingAsyncQueue.Policy
+    ) async throws {
+        let queue1 = CoalescingAsyncQueue()
+        let queue2 = CoalescingAsyncQueue()
+        
+        // Test all combinations:
+        // - perform(policy:)
+        // - addTask(policy:)
+        
+        try await queue2.perform(policy: policy) {
+            try await queue1.perform(policy: policy) {
+                queue2.preconditionSerialized()
+                queue1.preconditionSerialized()
+            }
+            
+            try await queue1
+                .addTask(policy: policy) {
+                    queue2.preconditionSerialized()
+                    queue1.preconditionSerialized()
+                }
+                .value
+        }
+        
+        try await queue2
+            .addTask(policy: policy) {
+                try await queue1.perform(policy: policy) {
+                    queue2.preconditionSerialized()
+                    queue1.preconditionSerialized()
+                }
+                
+                try await queue1
+                    .addTask(policy: policy) {
+                        queue2.preconditionSerialized()
+                        queue1.preconditionSerialized()
+                    }
+                    .value
+            }
+            .value
+    }
+
     // MARK: - Isolation
     
     @Test

--- a/Tests/QueueTests/DiscardingAsyncQueueTests.swift
+++ b/Tests/QueueTests/DiscardingAsyncQueueTests.swift
@@ -51,6 +51,47 @@ struct DiscardingAsyncQueueTests {
     }
     
     @Test
+    func perform_returns_non_sendable_value() async throws {
+        class NonSendable { }
+        
+        @globalActor actor MyGlobalActor {
+            static let shared = MyGlobalActor()
+        }
+        
+        let queue = DiscardingAsyncQueue()
+        
+        do {
+            let value = NonSendable()
+            let result = try await queue.perform {
+                return value
+            }
+            #expect(result === value)
+        }
+        
+        // Won't compile.
+        //
+        // do {
+        //     let value = NonSendable()
+        //     let result = try await queue.perform { @MyGlobalActor in
+        //         return value
+        //     }
+        //     #expect(result === value)
+        // }
+        
+        do {
+            let _ = try await queue.perform {
+                return NonSendable()
+            }
+        }
+        
+        do {
+            let _ = try await queue.perform { @MyGlobalActor in
+                return NonSendable()
+            }
+        }
+    }
+    
+    @Test
     func perform_rethrows_thrown_error() async throws {
         struct TestError: Error { }
         let queue = DiscardingAsyncQueue()


### PR DESCRIPTION
This pull request fixes #2 by adding a `preconditionSerialized()` method to all queues.

```swift
let queue = AsyncQueue()

await queue.perform {
  // Pass
  queue.preconditionSerialized()
}

// Crash
queue.preconditionSerialized()
```
